### PR TITLE
Updated comments use correct sample code for Dataframe joins

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -337,11 +337,11 @@ class DataFrame protected[sql](
    * {{{
    *   // Scala:
    *   import org.apache.spark.sql.functions._
-   *   df1.join(df2, "outer", $"df1Key" === $"df2Key")
+   *   df1.join(df2, $"df1Key" === $"df2Key", "outer")
    *
    *   // Java:
    *   import static org.apache.spark.sql.functions.*;
-   *   df1.join(df2, "outer", col("df1Key") === col("df2Key"));
+   *   df1.join(df2, col("df1Key") === col("df2Key"), "outer");
    * }}}
    *
    * @param right Right side of the join.


### PR DESCRIPTION
The API signatire for join requires the JoinType to be the third parameter. The code examples provided for join show JoinType being provided as the 2nd parameter resulting in errors (i.e. "df1.join(df2, "outer", $"df1Key" === $"df2Key") ). The correct example should be df1.join(df2, $"df1Key" === $"df2Key", "outer")
